### PR TITLE
Query by service, display state/networks/ids etc and resolve

### DIFF
--- a/cmd/ucp_service.go
+++ b/cmd/ucp_service.go
@@ -6,10 +6,22 @@ import (
 	"github.com/thebsdbox/diver/pkg/ucp"
 )
 
+var svc ucp.ServiceQuery
+
 func init() {
 	// Service flags
-	ucpService.Flags().StringVar(&name, "name", "", "Examine a service by name")
+	ucpService.Flags().StringVar(&svc.ServiceName, "name", "", "Examine a service by name")
+
+	// Query options
+	ucpService.Flags().BoolVar(&svc.ID, "id", false, "Display task ID")
+	ucpService.Flags().BoolVar(&svc.Networks, "networks", false, "Display task Network connections")
+	ucpService.Flags().BoolVar(&svc.State, "state", false, "Display task state")
+	ucpService.Flags().BoolVar(&svc.Resolve, "resolve", false, "Resolve Task IDs to human readable names")
+
+	// Set logging
 	ucpService.Flags().IntVar(&logLevel, "logLevel", 4, "Set the logging level [0=panic, 3=warning, 5=debug]")
+
+	// Add Service to UCP root commands
 	UCPRoot.AddCommand(ucpService)
 }
 
@@ -26,11 +38,8 @@ var ucpService = &cobra.Command{
 		}
 		log.Debugf("Looking for service [%s]", name)
 
-		if name != "" {
-			query := ucp.ServiceQuery{
-				ServiceName: name,
-			}
-			err = client.QueryServiceContainers(&query)
+		if svc.ServiceName != "" {
+			err = client.QueryServiceContainers(&svc)
 			if err != nil {
 				log.Fatalf("%v", err)
 			}

--- a/pkg/ucp/ucpContainers.go
+++ b/pkg/ucp/ucpContainers.go
@@ -45,6 +45,24 @@ func (c *Client) GetContainerCount() error {
 	return nil
 }
 
+// GetContainerFromID - this will find a container and return it's struct
+func (c *Client) GetContainerFromID(i string) (*types.ContainerJSONBase, error) {
+	log.Debugf("Retrieving all containers")
+	url := fmt.Sprintf("%s/containers/%s/json", c.UCPURL, i)
+
+	response, err := c.getRequest(url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var container types.ContainerJSONBase
+	err = json.Unmarshal(response, &container)
+	if err != nil {
+		return nil, err
+	}
+	return &container, nil
+}
+
 // GetContainerNames - lists the names of all containers
 func (c *Client) GetContainerNames() error {
 	response, err := c.getAllContainers()

--- a/pkg/ucp/ucpNetworks.go
+++ b/pkg/ucp/ucpNetworks.go
@@ -36,3 +36,21 @@ func (c *Client) GetNetworks() error {
 	}
 	return nil
 }
+
+// GetNetworkFromID - this will find a container and return it's struct
+func (c *Client) GetNetworkFromID(i string) (*types.NetworkResource, error) {
+	log.Debugf("Retrieving all containers")
+	url := fmt.Sprintf("%s/networks/%s", c.UCPURL, i)
+
+	response, err := c.getRequest(url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var network types.NetworkResource
+	err = json.Unmarshal(response, &network)
+	if err != nil {
+		return nil, err
+	}
+	return &network, nil
+}


### PR DESCRIPTION
Capability to examine services in more detail and resolve them to make debugging more clear:
`./diver ucp service --name urchin_urchin --state --id --networks --resolve`

```
/urchin_urchin.3.09052lkmcy8kgyi90umowv2ce      10.255.0.37/16  ingress 10.0.0.26/24    urchin_default  running
/urchin_urchin.34.0zo3kt73c0symk1ai4gdasqew     10.255.0.50/16  ingress 10.0.0.39/24    urchin_default  running
```