### PR TITLE
Correct Usage to link replica to node

### DIFF
--- a/cmd/dtr.go
+++ b/cmd/dtr.go
@@ -14,7 +14,7 @@ import (
 )
 
 var dtrClient dtr.Client
-var webhook dtrTypes.DTRWebHook
+var webhook dtrtypes.DTRWebHook
 
 func init() {
 	dtrLogin.Flags().StringVar(&dtrClient.Username, "username", os.Getenv("DTR_USERNAME"), "Username that has permissions to authenticate to Docker EE")
@@ -90,11 +90,21 @@ var dtrLoginReplicas = &cobra.Command{
 			// Fatal error if can't read the token
 			log.Fatalf("%v", err)
 		}
-		err = client.ListReplicas()
+		dc, err := client.DTRClusterStatus()
 		if err != nil {
 			// Fatal error if can't read the token
 			log.Fatalf("%v", err)
 		}
+
+		const padding = 3
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, padding, ' ', 0)
+		fmt.Fprintln(w, "Replica\tNode")
+
+		for replica, settings := range dc.ReplicaSettings {
+			fmt.Fprintf(w, "%s\t%s\n", replica, settings.Node)
+		}
+		w.Flush()
+
 	},
 }
 

--- a/pkg/dtr/dtrInfo.go
+++ b/pkg/dtr/dtrInfo.go
@@ -9,7 +9,7 @@ import (
 	"github.com/thebsdbox/diver/pkg/dtr/types"
 )
 
-func (c *Client) dtrClusterStatus() (*dtrTypes.DTRCluster, error) {
+func (c *Client) dtrClusterStatus() (*dtrtypes.DTRCluster, error) {
 
 	url := fmt.Sprintf("%s/api/v0/meta/cluster_status?refresh_token=%s", c.DTRURL, c.Token)
 
@@ -18,7 +18,26 @@ func (c *Client) dtrClusterStatus() (*dtrTypes.DTRCluster, error) {
 		return nil, err
 	}
 	//log.Debugf("%v", string(response))
-	var info dtrTypes.DTRCluster
+	var info dtrtypes.DTRCluster
+
+	err = json.Unmarshal(response, &info)
+	if err != nil {
+		return nil, err
+	}
+	return &info, nil
+}
+
+//DTRClusterStatus -
+func (c *Client) DTRClusterStatus() (*dtrtypes.DTRSettings, error) {
+
+	url := fmt.Sprintf("%s/api/v0/meta/settings?refresh_token=%s", c.DTRURL, c.Token)
+
+	response, err := c.getRequest(url, nil)
+	if err != nil {
+		return nil, err
+	}
+	//log.Debugf("%v", string(response))
+	var info dtrtypes.DTRSettings
 
 	err = json.Unmarshal(response, &info)
 	if err != nil {

--- a/pkg/dtr/dtrWebhooks.go
+++ b/pkg/dtr/dtrWebhooks.go
@@ -9,7 +9,7 @@ import (
 )
 
 //ListWebhooks -
-func (c *Client) ListWebhooks() ([]dtrTypes.DTRWebHook, error) {
+func (c *Client) ListWebhooks() ([]dtrtypes.DTRWebHook, error) {
 
 	url := fmt.Sprintf("%s/api/v0/webhooks?webhookType=any&refresh_token=%s", c.DTRURL, c.Token)
 
@@ -18,7 +18,7 @@ func (c *Client) ListWebhooks() ([]dtrTypes.DTRWebHook, error) {
 		return nil, err
 	}
 	//log.Debugf("%v", string(response))
-	var info []dtrTypes.DTRWebHook
+	var info []dtrtypes.DTRWebHook
 
 	err = json.Unmarshal(response, &info)
 	if err != nil {
@@ -29,7 +29,7 @@ func (c *Client) ListWebhooks() ([]dtrTypes.DTRWebHook, error) {
 }
 
 //CreateWebhook -
-func (c *Client) CreateWebhook(webhook dtrTypes.DTRWebHook) error {
+func (c *Client) CreateWebhook(webhook dtrtypes.DTRWebHook) error {
 
 	url := fmt.Sprintf("%s/api/v0/webhooks?refresh_token=%s", c.DTRURL, c.Token)
 

--- a/pkg/dtr/types/dtrTypes.go
+++ b/pkg/dtr/types/dtrTypes.go
@@ -1,4 +1,4 @@
-package dtrTypes
+package dtrtypes
 
 import "time"
 
@@ -125,3 +125,46 @@ type DTRWebHook struct {
 	SuccessfulAt string `json:"autlastSuccessfulAthorID"`
 	InActive     bool   `json:"inactive"`
 }
+
+//DTRSettings -
+type DTRSettings struct {
+	DtrHost                string `json:"dtrHost"`
+	Sso                    bool   `json:"sso"`
+	CreateRepositoryOnPush bool   `json:"createRepositoryOnPush"`
+	ReplicaSettings        map[string]struct {
+		HTTPPort  int    `json:"HTTPPort"`
+		HTTPSPort int    `json:"HTTPSPort"`
+		Node      string `json:"node"`
+	} `json:"replicaSettings"`
+	HTTPProxy                 string `json:"httpProxy"`
+	HTTPSProxy                string `json:"httpsProxy"`
+	NoProxy                   string `json:"noProxy"`
+	DisableUpgrades           bool   `json:"disableUpgrades"`
+	ReportAnalytics           bool   `json:"reportAnalytics"`
+	AnonymizeAnalytics        bool   `json:"anonymizeAnalytics"`
+	DisableBackupWarning      bool   `json:"disableBackupWarning"`
+	LogProtocol               string `json:"logProtocol"`
+	LogHost                   string `json:"logHost"`
+	LogLevel                  string `json:"logLevel"`
+	WebTLSCert                string `json:"webTLSCert"`
+	WebTLSCA                  string `json:"webTLSCA"`
+	ReplicaID                 string `json:"replicaID"`
+	ScanningEnabled           bool   `json:"scanningEnabled"`
+	ScanningSyncOnline        bool   `json:"scanningSyncOnline"`
+	ScanningEnableAutoRecheck bool   `json:"scanningEnableAutoRecheck"`
+	JobHistoryToKeep          int    `json:"jobHistoryToKeep"`
+	StorageVolume             string `json:"storageVolume"`
+	NfsHost                   string `json:"nfsHost"`
+	NfsPath                   string `json:"nfsPath"`
+}
+
+// Seven79Bef5C7C10 struct {
+// 	HTTPPort  int    `json:"HTTPPort"`
+// 	HTTPSPort int    `json:"HTTPSPort"`
+// 	Node      string `json:"node"`
+// } `json:"779bef5c7c10"`
+// Eb3Bccc35F95 struct {
+// 	HTTPPort  int    `json:"HTTPPort"`
+// 	HTTPSPort int    `json:"HTTPSPort"`
+// 	Node      string `json:"node"`
+// } `json:"eb3bccc35f95"`


### PR DESCRIPTION
Replaces the original cluster-info with information that links the replicas to an actual node