### PR TITLE
Refactor and expand client bundle support

### DIFF
--- a/cmd/ucp.go
+++ b/cmd/ucp.go
@@ -32,7 +32,6 @@ func init() {
 	ucpContainer.Flags().BoolVar(&top, "top", false, "Enable TOP for watching running containers")
 
 	UCPRoot.AddCommand(ucpContainer)
-	UCPRoot.AddCommand(ucpCliBundle)
 	UCPRoot.AddCommand(ucpLogin)
 
 	// Sub commands
@@ -131,24 +130,5 @@ var ucpContainerList = &cobra.Command{
 			log.Fatalf("%v", err)
 		}
 		return
-	},
-}
-
-var ucpCliBundle = &cobra.Command{
-	Use:   "client-bundle",
-	Short: "Download the client bundle for UCP",
-	Run: func(cmd *cobra.Command, args []string) {
-		log.SetLevel(log.Level(logLevel))
-
-		client, err := ucp.ReadToken()
-		if err != nil {
-			// Fatal error if can't read the token
-			log.Fatalf("%v", err)
-		}
-		err = client.GetClientBundle()
-		if err != nil {
-			log.Fatalf("%v", err)
-		}
-
 	},
 }

--- a/cmd/ucp_client_bundles.go
+++ b/cmd/ucp_client_bundles.go
@@ -1,0 +1,139 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/thebsdbox/diver/pkg/ucp"
+)
+
+var username string
+
+func init() {
+
+	ucpCliBundleList.Flags().StringVar(&username, "username", "", "Username to list bundle for (default: logged-in user)")
+
+	ucpCliBundleDelete.Flags().StringVar(&username, "username", "", "Username to delete bundle for (default: logged-in user)")
+
+	ucpCliBundleRename.Flags().StringVar(&username, "username", "", "Username to rename bundle for (default: logged-in user)")
+
+	ucpCliBundle.AddCommand(ucpCliBundleDownload)
+	ucpCliBundle.AddCommand(ucpCliBundleList)
+
+	if !DiverRO {
+		ucpCliBundle.AddCommand(ucpCliBundleRename)
+		ucpCliBundle.AddCommand(ucpCliBundleDelete)
+	}
+
+	UCPRoot.AddCommand(ucpCliBundle)
+}
+
+// ucpCliBundle kept as an alias for `diver ucp client-bundle download` to preserve compatibility, may be deprecated later?
+var ucpCliBundle = &cobra.Command{
+	Use:   "client-bundle",
+	Short: "Download the client bundle for UCP",
+	Run: func(cmd *cobra.Command, args []string) {
+		log.SetLevel(log.Level(logLevel))
+
+		client, err := ucp.ReadToken()
+		if err != nil {
+			// Fatal error if can't read the token
+			log.Fatalf("%v", err)
+		}
+		err = client.GetClientBundle()
+		if err != nil {
+			log.Fatalf("%v", err)
+		}
+
+	},
+}
+
+var ucpCliBundleDownload = &cobra.Command{
+	Use:   "get",
+	Short: "Download the client bundle for UCP",
+	Run: func(cmd *cobra.Command, args []string) {
+		log.SetLevel(log.Level(logLevel))
+
+		client, err := ucp.ReadToken()
+		if err != nil {
+			// Fatal error if can't read the token
+			log.Fatalf("%v", err)
+		}
+		err = client.GetClientBundle()
+		if err != nil {
+			log.Fatalf("%v", err)
+		}
+
+	},
+}
+
+var ucpCliBundleList = &cobra.Command{
+	Use:   "ls",
+	Short: "List client bundles for UCP",
+	Run: func(cmd *cobra.Command, args []string) {
+		log.SetLevel(log.Level(logLevel))
+
+		client, err := ucp.ReadToken()
+		if err != nil {
+			// Fatal error if can't read the token
+			log.Fatalf("%v", err)
+		}
+		clientBundles, err := client.ListClientBundles(username)
+		if err != nil {
+			log.Fatalf("%v", err)
+		}
+
+		const padding = 3
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, padding, ' ', 0)
+		fmt.Fprintln(w, "ID\tLabel")
+
+		for _, publicKey := range clientBundles.AccountPublicKeys {
+			fmt.Fprintf(w, "%s\t%s\n", publicKey.ID, publicKey.Label)
+		}
+		w.Flush()
+
+	},
+}
+
+var ucpCliBundleRename = &cobra.Command{
+	Use:   "rename BUNDLE_ID NEW_LABEL",
+	Short: "Rename client bundle for UCP",
+	Args:  cobra.ExactArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		log.SetLevel(log.Level(logLevel))
+
+		client, err := ucp.ReadToken()
+		if err != nil {
+			// Fatal error if can't read the token
+			log.Fatalf("%v", err)
+		}
+		err = client.RenameClientBundle(username, args[0], args[1])
+		if err != nil {
+			log.Fatalf("%v", err)
+		}
+
+	},
+}
+
+var ucpCliBundleDelete = &cobra.Command{
+	Use:   "rm BUNDLE_ID",
+	Short: "Delete client bundle for UCP",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		log.SetLevel(log.Level(logLevel))
+
+		client, err := ucp.ReadToken()
+		if err != nil {
+			// Fatal error if can't read the token
+			log.Fatalf("%v", err)
+		}
+		err = client.DeleteClientBundle(username, args[0])
+		if err != nil {
+			log.Fatalf("%v", err)
+		}
+
+	},
+}

--- a/pkg/ucp/types/ucpTypes.go
+++ b/pkg/ucp/types/ucpTypes.go
@@ -99,3 +99,17 @@ type InterlockConfig struct {
 	Arch             string `json:"Arch"`
 	InterlockEnabled bool   `json:"InterlockEnabled"`
 }
+
+// ClientBundles - defines a client bundle list response
+type ClientBundles struct {
+	AccountPublicKeys []struct {
+		ID           string `json:"id"`
+		AccountID    string `json:"accountID"`
+		PublicKey    string `json:"publicKey"`
+		Label        string `json:"label"`
+		Certificates []struct {
+			Label string `json:"label"`
+			Cert  string `json:"cert"`
+		} `json:"certificates"`
+	} `json:"accountPublicKeys"`
+}

--- a/pkg/ucp/ucpAuth.go
+++ b/pkg/ucp/ucpAuth.go
@@ -1,11 +1,9 @@
 package ucp
 
 import (
-	"bytes"
 	"encoding/csv"
 	"encoding/json"
 	"fmt"
-	"io"
 	"os"
 	"strconv"
 
@@ -32,33 +30,6 @@ func (c *Client) AuthStatus() (*ucptypes.Account, error) {
 	}
 
 	return &a, nil
-}
-
-//GetClientBundle - will download the UCP Client Bundle
-func (c *Client) GetClientBundle() error {
-
-	log.Infoln("Downloading the UCP Client Bundle")
-	// Create the file
-	out, err := os.Create("ucp-bundle.zip")
-	if err != nil {
-		return err
-	}
-	defer out.Close()
-
-	log.Debugln("Retrieving Client Bundle")
-	url := fmt.Sprintf("%s/api/clientbundle", c.UCPURL)
-
-	response, err := c.getRequest(url, nil)
-	if err != nil {
-		return err
-	}
-
-	_, err = io.Copy(out, bytes.NewReader(response))
-	if err != nil {
-		return err
-	}
-
-	return nil
 }
 
 // NewAccount - Creates a new account within UCP

--- a/pkg/ucp/ucpClientBundles.go
+++ b/pkg/ucp/ucpClientBundles.go
@@ -1,0 +1,151 @@
+package ucp
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/thebsdbox/diver/pkg/ucp/types"
+)
+
+// GetClientBundle - will download the UCP Client Bundle
+func (c *Client) GetClientBundle() error {
+
+	log.Infoln("Downloading the UCP Client Bundle")
+	// Create the file
+	out, err := os.Create("ucp-bundle.zip")
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	log.Debugln("Retrieving Client Bundle")
+	url := fmt.Sprintf("%s/api/clientbundle", c.UCPURL)
+
+	response, err := c.getRequest(url, nil)
+	if err != nil {
+		return err
+	}
+
+	_, err = io.Copy(out, bytes.NewReader(response))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ListClientBundles - will list UCP Client Bundle
+func (c *Client) ListClientBundles(user string) (*ucptypes.ClientBundles, error) {
+	if user == "" {
+		currentAccount, err := c.AuthStatus()
+		if err != nil {
+			log.Warn("Session has expired, please login")
+			return nil, err
+		}
+		user = currentAccount.Name
+	}
+	log.Debugln("Listing Client Bundles")
+
+	url := fmt.Sprintf("%s/accounts/%s/publicKeys", c.UCPURL, user)
+
+	var clientBundles ucptypes.ClientBundles
+
+	response, err := c.getRequest(url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if err != nil {
+		log.Debugf("response: %v", err)
+		parseerr := ParseUCPError([]byte(response))
+		if parseerr != nil {
+			log.Debugf("%s", response)
+			log.Errorf("Error parsing UCP error: %v", err)
+		}
+		return nil, err
+	}
+
+	err = json.Unmarshal(response, &clientBundles)
+	if err != nil {
+		return nil, err
+	}
+
+	return &clientBundles, nil
+}
+
+// RenameClientBundle - will relabel / rename the selected UCP Client Bundle
+func (c *Client) RenameClientBundle(user, keyID, name string) error {
+	if user == "" {
+		currentAccount, err := c.AuthStatus()
+		if err != nil {
+			log.Warn("Session has expired, please login")
+			return err
+		}
+		user = currentAccount.Name
+	}
+	log.Infoln("Renaming the UCP Client Bundle")
+	url := fmt.Sprintf("%s/accounts/%s/publicKeys/%s", c.UCPURL, user, keyID)
+
+	type bundleLabel struct {
+		Label string `json:"label"`
+	}
+
+	label := bundleLabel{Label: name}
+
+	b, err := json.Marshal(label)
+	if err != nil {
+		return nil
+	}
+
+	response, err := c.patchRequest(url, b)
+	if err != nil {
+		return err
+	}
+
+	if err != nil {
+		log.Debugf("response: %v", err)
+		parseerr := ParseUCPError([]byte(response))
+		if parseerr != nil {
+			log.Debugf("%s", response)
+			log.Errorf("Error parsing UCP error: %v", err)
+		}
+		return err
+	}
+
+	return nil
+}
+
+// DeleteClientBundle - will delete the selected UCP Client Bundle
+func (c *Client) DeleteClientBundle(user, keyID string) error {
+	if user == "" {
+		currentAccount, err := c.AuthStatus()
+		if err != nil {
+			log.Warn("Session has expired, please login")
+			return err
+		}
+		user = currentAccount.Name
+	}
+	log.Infoln("Deleting the UCP Client Bundle")
+	url := fmt.Sprintf("%s/accounts/%s/publicKeys/%s", c.UCPURL, user, keyID)
+
+	response, err := c.delRequest(url, nil)
+	if err != nil {
+		return err
+	}
+
+	if err != nil {
+		log.Debugf("response: %v", err)
+		parseerr := ParseUCPError([]byte(response))
+		if parseerr != nil {
+			log.Debugf("%s", response)
+			log.Errorf("Error parsing UCP error: %v", err)
+		}
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
- Expanded `client-bundle` to support listing (`ls`), renaming (`rename`) and deleting (`rm`).
- Refactored and broke out `client-bundle` command into it's own file.

Currently I've 'aliased' (copied and pasted :p) so that `diver ucp client-bundle` still works as it used to, but also now have `diver ucp client-bundle download` which does the same thing.

There's still some refactoring that we can do with `ls`, `rename` and `rm`, my code is probably pretty crappy there, just wanted to get something working.