### PR TITLE
Initial support work

### DIFF
--- a/cmd/ucp_support.go
+++ b/cmd/ucp_support.go
@@ -1,0 +1,41 @@
+package cmd
+
+import (
+	log "github.com/Sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/thebsdbox/diver/pkg/ucp"
+)
+
+func init() {
+
+	ucpSupport.AddCommand(ucpSupportDownload)
+
+	UCPRoot.AddCommand(ucpSupport)
+}
+
+var ucpSupport = &cobra.Command{
+	Use:   "support",
+	Short: "Download the client bundle for UCP",
+	Run: func(cmd *cobra.Command, args []string) {
+		log.SetLevel(log.Level(logLevel))
+		cmd.Help()
+	},
+}
+
+var ucpSupportDownload = &cobra.Command{
+	Use:   "get",
+	Short: "Download the support dump for UCP",
+	Run: func(cmd *cobra.Command, args []string) {
+		log.SetLevel(log.Level(logLevel))
+
+		client, err := ucp.ReadToken()
+		if err != nil {
+			// Fatal error if can't read the token
+			log.Fatalf("%v", err)
+		}
+		err = client.GetSupportDump()
+		if err != nil {
+			log.Fatalf("%v", err)
+		}
+	},
+}

--- a/pkg/ucp/ucpSupport.go
+++ b/pkg/ucp/ucpSupport.go
@@ -1,0 +1,37 @@
+package ucp
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+
+	log "github.com/Sirupsen/logrus"
+)
+
+// GetSupportDump - will download a UCP support dump
+func (c *Client) GetSupportDump() error {
+
+	// TODO add a spinner here
+	log.Infoln("Downloading a UCP support dump (may take some time)")
+	// Create the file
+	out, err := os.Create("support-dump.zip")
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	url := fmt.Sprintf("%s/api/support", c.UCPURL)
+
+	response, err := c.postRequest(url, nil)
+	if err != nil {
+		return err
+	}
+
+	_, err = io.Copy(out, bytes.NewReader(response))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
Add initial functionality to download a support dump. Would be great to add a spinner for longer downloads like this and the CVE DB in store. Unfortunately the support dump is streamed (no content-length) so can't add a progress bar. 