### PR TITLE
Added login contexts, allows multiple UCP sessions

### DIFF
--- a/cmd/ucp.go
+++ b/cmd/ucp.go
@@ -2,8 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
-	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/thebsdbox/diver/pkg/ucp"
@@ -16,14 +14,6 @@ var importPath, exportPath, action string
 var top, exampleFile bool
 
 func init() {
-	ucpLogin.Flags().StringVar(&ucpClient.Username, "username", os.Getenv("UCP_USERNAME"), "Username that has permissions to authenticate to Docker EE")
-	ucpLogin.Flags().StringVar(&ucpClient.Password, "password", os.Getenv("UCP_PASSWORD"), "Password allowing a user to authenticate to Docker EE")
-	ucpLogin.Flags().StringVar(&ucpClient.UCPURL, "url", os.Getenv("UCP_URL"), "URL for Docker Universal Control Plane, e.g. https://10.0.0.1")
-	ignoreCert := strings.ToLower(os.Getenv("UCP_INSECURE")) == "true"
-
-	ucpLogin.Flags().BoolVar(&ucpClient.IgnoreCert, "ignorecert", ignoreCert, "Ignore x509 certificate")
-
-	UCPRoot.AddCommand(ucpLogin)
 
 	// Add UCP and subcommands to the main application
 	diverCmd.AddCommand(UCPRoot)
@@ -40,7 +30,7 @@ var UCPRoot = &cobra.Command{
 		if err != nil {
 			// Fatal error if can't read the token
 			cmd.Help()
-			log.Warn("Unable to find existing session, please login")
+			log.Errorf("%v", err)
 			return
 		}
 		currentAccount, err := existingClient.AuthStatus()
@@ -53,28 +43,5 @@ var UCPRoot = &cobra.Command{
 		fmt.Printf("\n\n")
 		log.Infof("Current user [%s]", currentAccount.Name)
 		return
-	},
-}
-
-// UCPRoot - This is the root of all UCP commands / flags
-var ucpLogin = &cobra.Command{
-	Use:   "login",
-	Short: "Authenticate against the Universal Control Pane",
-	Run: func(cmd *cobra.Command, args []string) {
-		log.SetLevel(log.Level(logLevel))
-
-		err := ucpClient.Connect()
-
-		// Check if connection was succesful
-		if err != nil {
-			log.Fatalf("%v", err)
-		} else {
-			// If succesfull write the token and annouce as succesful
-			err = ucpClient.WriteToken()
-			if err != nil {
-				log.Errorf("%v", err)
-			}
-			log.Infof("Succesfully logged into [%s]", ucpClient.UCPURL)
-		}
 	},
 }

--- a/cmd/ucp_login.go
+++ b/cmd/ucp_login.go
@@ -1,0 +1,92 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/thebsdbox/diver/pkg/ucp"
+)
+
+var session int
+
+func init() {
+	diverCmd.AddCommand(UCPRoot)
+
+	ucpLogin.Flags().StringVar(&ucpClient.Username, "username", os.Getenv("UCP_USERNAME"), "Username that has permissions to authenticate to Docker EE")
+	ucpLogin.Flags().StringVar(&ucpClient.Password, "password", os.Getenv("UCP_PASSWORD"), "Password allowing a user to authenticate to Docker EE")
+	ucpLogin.Flags().StringVar(&ucpClient.UCPURL, "url", os.Getenv("UCP_URL"), "URL for Docker EE, e.g. https://10.0.0.1")
+	ignoreCert := strings.ToLower(os.Getenv("UCP_INSECURE")) == "true"
+
+	ucpLogin.Flags().BoolVar(&ucpClient.IgnoreCert, "ignorecert", ignoreCert, "Ignore x509 certificate")
+
+	ucpLoginSet.Flags().IntVar(&session, "id", 0, "The session ID to set to active")
+
+	ucpLogin.AddCommand(ucpLoginList)
+	ucpLogin.AddCommand(ucpLoginSet)
+
+	UCPRoot.AddCommand(ucpLogin)
+}
+
+// UCPLogin - This manages logging in and swapping of contexts
+var ucpLogin = &cobra.Command{
+	Use:   "login",
+	Short: "Authenticate against the Universal Control Pane",
+	Run: func(cmd *cobra.Command, args []string) {
+		log.SetLevel(log.Level(logLevel))
+
+		err := ucpClient.Connect()
+
+		// Check if connection was succesful
+		if err != nil {
+			cmd.Help()
+			log.Fatalf("%v", err)
+		} else {
+			// If succesfull write the token and annouce as succesful
+			err = ucpClient.WriteToken()
+			if err != nil {
+				log.Errorf("%v", err)
+			}
+			log.Infof("Succesfully logged into [%s]", ucpClient.UCPURL)
+		}
+	},
+}
+
+// ucpLoginList - This manages logging in and swapping of contexts
+var ucpLoginList = &cobra.Command{
+	Use:   "list",
+	Short: "List all UCP sessions",
+	Run: func(cmd *cobra.Command, args []string) {
+		log.SetLevel(log.Level(logLevel))
+		// Retrieve all of the client sessions in the token file
+		clientTokens, err := ucp.ReadAllClients()
+		if err != nil {
+			log.Errorf("%v", err)
+		}
+
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, tabPadding, ' ', 0)
+		fmt.Fprintln(w, "ID\tAddress\tActive")
+		for i := range clientTokens {
+			fmt.Fprintf(w, "%d\t%s\t%t\n", i, clientTokens[i].UCPAddress, clientTokens[i].Active)
+		}
+		w.Flush()
+	},
+}
+
+// ucpLoginSet - This manages logging in and swapping of contexts
+var ucpLoginSet = &cobra.Command{
+	Use:   "setActive",
+	Short: "Set the active UCP session",
+	Run: func(cmd *cobra.Command, args []string) {
+		log.SetLevel(log.Level(logLevel))
+
+		err := ucp.SetActiveSession(session)
+		if err != nil {
+			log.Fatalf("%v", err)
+		}
+		log.Infof("Set session [%d] to active", session)
+	},
+}

--- a/docs/ucp/README.md
+++ b/docs/ucp/README.md
@@ -12,6 +12,28 @@ INFO[0000] Succesfully logged into [https://docker01.fnnrn.me]
 
 **Note** the `login` command will create a `~/.ucptoken` file that is used for all further `diver` commands. In the event that login errors start to occur, or logins fail check the permissions of this file or alternatively remove this file.
 
+### Working with multiple UCP sessions
+
+When you log into a new UCP server, then a new session will be created. To view the sessions that are available use the following command:
+
+```
+$ ./diver ucp login list
+ID   Address                     Active
+0    https://192.168.0.140       true
+1    https://docker01.fnnrn.me   false
+```
+
+To set a different session to active, you can use the setActive command to change the active session.
+
+```
+./diver ucp login setActive --id 1
+INFO[0000] Set session [1] to active
+./diver ucp login list
+ID   Address                     Active
+0    https://192.168.0.140       false
+1    https://docker01.fnnrn.me   true
+```
+
 
 ### Checking access
 


### PR DESCRIPTION
The `login` subcommand now has two new commands:

- `list` lists the sessions that can be used
- `setActive` set the active session that should be used.