### PR TITLE
Fix interlock version discrepancy

### DIFF
--- a/cmd/ucp_interlock.go
+++ b/cmd/ucp_interlock.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"strings"
+
 	log "github.com/Sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/thebsdbox/diver/pkg/ucp"
@@ -30,7 +32,11 @@ var ucpInterlock = &cobra.Command{
 			// Fatal error if can't read the token
 			log.Fatalf("%v", err)
 		}
-		err = client.ConfigureInterlock(interlockConfig)
+		if strings.HasPrefix(client.UCPVersion, "ucp/2") {
+			err = client.ConfigureHRM(interlockConfig)
+		} else {
+			err = client.ConfigureInterlock(interlockConfig)
+		}
 		if err != nil {
 			// Fatal error if can't configure Interlock
 			log.Fatalf("%v", err)

--- a/pkg/ucp/types/ucpTypes.go
+++ b/pkg/ucp/types/ucpTypes.go
@@ -100,6 +100,13 @@ type InterlockConfig struct {
 	InterlockEnabled bool   `json:"InterlockEnabled"`
 }
 
+// HRMConfig - configuration for HRM layer 7 routing
+type HRMConfig struct {
+	HTTPPort  int    `json:"HTTPPort"`
+	HTTPSPort int    `json:"HTTPSPort"`
+	Arch      string `json:"Arch"`
+}
+
 // ClientBundles - defines a client bundle list response
 type ClientBundles struct {
 	AccountPublicKeys []struct {

--- a/pkg/ucp/ucpHRM.go
+++ b/pkg/ucp/ucpHRM.go
@@ -1,0 +1,38 @@
+package ucp
+
+import (
+	"encoding/json"
+	"fmt"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/thebsdbox/diver/pkg/ucp/types"
+)
+
+// ConfigureHRM - This will toggle the functionality to enable Image Scanning
+func (c *Client) ConfigureHRM(interlockConfig ucptypes.InterlockConfig) error {
+	var hrmConfig ucptypes.HRMConfig
+	url := fmt.Sprintf("%s/api/hrm", c.UCPURL)
+
+	log.Debugf("Setting HRM set to [%t]", interlockConfig.InterlockEnabled)
+
+	hrmConfig.Arch = interlockConfig.Arch
+	hrmConfig.HTTPPort = interlockConfig.HTTPPort
+	hrmConfig.HTTPSPort = interlockConfig.HTTPSPort
+
+	b, err := json.Marshal(hrmConfig)
+	if err != nil {
+		return nil
+	}
+
+	if !interlockConfig.InterlockEnabled {
+		_, err = c.delRequest(url, nil)
+	} else {
+		_, err = c.postRequest(url, b)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
Fixes #103 

- Added version to the written token so it's available to all operations
- Tried to keep interlock as 'default' as possible, and branch out to HRM at a single point so it's easy to remove later when HRM / v2.x is EOL.
- Didn't add any handling for < 2.x as EOL
