### PR TITLE
Duplicate UCP subcommand

### DIFF
--- a/cmd/ucp_login.go
+++ b/cmd/ucp_login.go
@@ -14,7 +14,6 @@ import (
 var session int
 
 func init() {
-	diverCmd.AddCommand(UCPRoot)
 
 	ucpLogin.Flags().StringVar(&ucpClient.Username, "username", os.Getenv("UCP_USERNAME"), "Username that has permissions to authenticate to Docker EE")
 	ucpLogin.Flags().StringVar(&ucpClient.Password, "password", os.Getenv("UCP_PASSWORD"), "Password allowing a user to authenticate to Docker EE")


### PR DESCRIPTION
Copy and paste of code into `ucp_login.go` resulted in a duplicate UCP subcommand