### PR TITLE
Filter store info by os

### DIFF
--- a/cmd/store.go
+++ b/cmd/store.go
@@ -13,7 +13,7 @@ import (
 )
 
 var storeClient store.Client
-var id, version string
+var id, version, productOS string
 var firstActive, trialurl, url bool
 
 func init() {
@@ -28,6 +28,7 @@ func init() {
 
 	storeSubscriptionsList.Flags().StringVar(&id, "id", "", "Docker Store ID, by default will take the ID from ~/.storetoken")
 	storeSubscriptionsList.Flags().BoolVar(&firstActive, "firstactive", false, "Retrieve first active subscription")
+	storeSubscriptionsList.Flags().StringVar(&productOS, "os", "", "Only display subscription information for this OS")
 	storeSubscriptionsList.Flags().BoolVar(&trialurl, "trial", false, "Retrieve first active subscription as a trial URL")
 	storeSubscriptionsList.Flags().BoolVar(&url, "url", false, "Retrieve first active subscription as a URL")
 
@@ -94,6 +95,8 @@ var storeSubscriptionsList = &cobra.Command{
 	Use:   "list",
 	Short: "List Docker Store subscriptions",
 	Run: func(cmd *cobra.Command, args []string) {
+		var subscriptionsFound = false
+		var productToMatch = "docker-ee-server-" + strings.ToLower(productOS)
 		log.SetLevel(log.Level(logLevel))
 
 		existingClient, err := store.ReadToken()
@@ -111,6 +114,9 @@ var storeSubscriptionsList = &cobra.Command{
 
 		if firstActive == true || trialurl == true || url == true {
 			for i := range subs {
+				if productOS != "" && subs[i].ProductID != productToMatch {
+					continue
+				}
 				if subs[i].State == "active" {
 					if firstActive {
 						fmt.Printf("%s\n", subs[i].SubscriptionID)
@@ -131,7 +137,19 @@ var storeSubscriptionsList = &cobra.Command{
 		w := tabwriter.NewWriter(os.Stdout, 0, 0, tabPadding, ' ', 0)
 		fmt.Fprintln(w, "Subscriptiob Name\tSubscription ID\tState")
 		for i := range subs {
+			if productOS != "" && subs[i].ProductID != productToMatch {
+				continue
+			}
 			fmt.Fprintf(w, "%s\t%s\t%s\n", subs[i].Name, subs[i].SubscriptionID, subs[i].State)
+			subscriptionsFound = true
+		}
+
+		if !subscriptionsFound {
+			if productOS == "" {
+				fmt.Fprintf(w, "No subscriptions found.\n")
+			} else {
+				fmt.Fprintf(w, "No subscriptions found matching: %s.\n", productOS)
+			}
 		}
 
 		w.Flush()

--- a/cmd/store.go
+++ b/cmd/store.go
@@ -135,12 +135,12 @@ var storeSubscriptionsList = &cobra.Command{
 		}
 
 		w := tabwriter.NewWriter(os.Stdout, 0, 0, tabPadding, ' ', 0)
-		fmt.Fprintln(w, "Subscriptiob Name\tSubscription ID\tState")
+		fmt.Fprintln(w, "Subscription Name\tProduct ID\tSubscription ID\tState")
 		for i := range subs {
 			if productOS != "" && subs[i].ProductID != productToMatch {
 				continue
 			}
-			fmt.Fprintf(w, "%s\t%s\t%s\n", subs[i].Name, subs[i].SubscriptionID, subs[i].State)
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", subs[i].Name, subs[i].ProductID, subs[i].SubscriptionID, subs[i].State)
 			subscriptionsFound = true
 		}
 

--- a/cmd/store.go
+++ b/cmd/store.go
@@ -146,9 +146,9 @@ var storeSubscriptionsList = &cobra.Command{
 
 		if !subscriptionsFound {
 			if productOS == "" {
-				fmt.Fprintf(w, "No subscriptions found.\n")
+				log.Fatalln("No subscriptions found.")
 			} else {
-				fmt.Fprintf(w, "No subscriptions found matching: %s.\n", productOS)
+				log.Fatalf("No subscriptions found matching: %s.", productOS)
 			}
 		}
 


### PR DESCRIPTION
Subscriptions can be issued per OS, so being able to filter by OS will be convenient.

This PR displays the product ID and permit filtering by OS:
```
$ diver store subscriptions  list 
Subscription Name                 Product ID                     Subscription ID                            State
1 Month Trial | Fri Aug 17 2018   docker-ee-server-ubuntu        sub-ffffffff-ffff-ffff-ffff-ffffffffffff   active
1 Month Trial | Tue Jul 31 2018   docker-ee-server-centos        sub-ffffffff-ffff-ffff-ffff-ffffffffffff   active
1 Month Trial | Tue Jul 31 2018   docker-ee-server-rhel          sub-ffffffff-ffff-ffff-ffff-ffffffffffff   active
1 Month Trial | Fri Jul 13 2018   docker-ee-server-sles          sub-ffffffff-ffff-ffff-ffff-ffffffffffff   expired
1 Month Trial | Wed Jul 11 2018   docker-ee-server-ubuntu        sub-ffffffff-ffff-ffff-ffff-ffffffffffff   expired
1 Month Trial | Thu Jun 28 2018   docker-ee-server-centos        sub-ffffffff-ffff-ffff-ffff-ffffffffffff   expired
```

```
$ diver store subscriptions  list --os Ubuntu --firstactive
sub-ffffffff-ffff-ffff-ffff-ffffffffffff
```

```
$ diver store subscriptions  list --os OS2 
FATA[0002] No subscriptions found matching: OS2. 
```