### PR TITLE
Initial LDAP support

### DIFF
--- a/cmd/ucp_ldap.go
+++ b/cmd/ucp_ldap.go
@@ -1,0 +1,135 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/thebsdbox/diver/pkg/ucp"
+	"github.com/thebsdbox/diver/pkg/ucp/types"
+)
+
+// This are the configurable options for LDAP
+var usernameLDAP, passwordLDAP, serverLDAP, baseDN, usernameAttribute string
+
+func init() {
+	ucpLDAPSet.Flags().StringVar(&serverLDAP, "server", "", "The hostname or IP address of the LDAP server")
+	ucpLDAPSet.Flags().StringVar(&serverLDAP, "username", "", "A username with read privileges for the LDAP server")
+	ucpLDAPSet.Flags().StringVar(&serverLDAP, "password", "", "A password for the LDAP server")
+	ucpLDAPSet.Flags().StringVar(&baseDN, "basedn", "", "The base Distinguished Name to search from e.g. dc=ad,dc=company,dc=com")
+	ucpLDAPSet.Flags().StringVar(&usernameAttribute, "userAttribute", "", "A password for the LDAP server")
+
+	ucpLDAP.AddCommand(ucpLDAPSet)
+	ucpLDAP.AddCommand(ucpLDAPGet)
+	UCPRoot.AddCommand(ucpLDAP)
+}
+
+var ucpLDAP = &cobra.Command{
+	Use:   "ldap",
+	Short: "Manage UCP and LDAP",
+	Run: func(cmd *cobra.Command, args []string) {
+		log.SetLevel(log.Level(logLevel))
+		cmd.Help()
+	},
+}
+
+var ucpLDAPGet = &cobra.Command{
+	Use:   "get",
+	Short: "Retrieve the LDAP configuration",
+	Run: func(cmd *cobra.Command, args []string) {
+		log.SetLevel(log.Level(logLevel))
+		client, err := ucp.ReadToken()
+		if err != nil {
+			log.Fatalf("%v", err)
+		}
+		cfg, err := client.GetLDAPInfo()
+		if err != nil {
+			log.Fatalf("%v", err)
+		}
+		printLDAPCfg(cfg)
+
+	},
+}
+
+// ucpLDAPSet will just configure the basics in the initial release
+// TODO - Add additional configuration abilities
+var ucpLDAPSet = &cobra.Command{
+	Use:   "set",
+	Short: "Configure the LDAP configuration",
+	Run: func(cmd *cobra.Command, args []string) {
+		log.SetLevel(log.Level(logLevel))
+		client, err := ucp.ReadToken()
+		if err != nil {
+			log.Fatalf("%v", err)
+		}
+		// Retrieve the existing configuration as we'll need to update it
+		existingCfg, err := client.GetLDAPInfo()
+		if err != nil {
+			log.Fatalf("%v", err)
+		}
+
+		if serverLDAP == "" && existingCfg.ServerURL == "" {
+			log.Fatalf("No LDAP server has been specified or configured")
+		}
+
+		// Update the Server URL
+		if serverLDAP != "" {
+			// Perform testing on the URL to ensure it matches the input requirements for the UCP API
+			if strings.HasPrefix(serverLDAP, "ldap://") {
+				existingCfg.ServerURL = serverLDAP
+			} else if strings.HasPrefix(serverLDAP, "ldaps://") {
+				existingCfg.ServerURL = serverLDAP
+			} else {
+				log.Fatalln("The LDAP server URL should begin with ldap:// or ldaps://")
+			}
+		}
+
+		// Update or set the Username for the LDAP server
+		if usernameLDAP != "" {
+			existingCfg.ReaderDN = usernameLDAP
+		}
+
+		// Update or set the Password for the LDAP server
+		if passwordLDAP != "" {
+			existingCfg.ReaderPassword = passwordLDAP
+		}
+
+		// See if a previous userSearch config exists
+		log.Debugf("Found [%d] search configurations", len(existingCfg.UserSearchConfigs))
+		if len(existingCfg.UserSearchConfigs) == 1 {
+			// If creating an entirely new Search Config
+
+			if baseDN == "" || usernameAttribute == "" {
+				log.Fatalln("Both --basedn and --userAttribute are needed for a new configuration")
+			} else {
+				log.Debugln("Updating base Search configuration")
+				existingCfg.UserSearchConfigs[0].BaseDN = baseDN
+				existingCfg.UserSearchConfigs[0].UserAttr = usernameAttribute
+			}
+		} else {
+			if baseDN != "" || usernameAttribute != "" {
+				log.Fatalln("Existing search configurations should be managed in the UI")
+			}
+		}
+		err = client.SetLDAPInfo(existingCfg)
+		if err != nil {
+			log.Fatalf("%v", err)
+		}
+		log.Infoln("Succesfully updated LDAP settings")
+	},
+}
+
+func printLDAPCfg(cfg *ucptypes.LDAPConfig) {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, tabPadding, ' ', 0)
+
+	fmt.Fprintf(w, "LDAP Server URL:\t%s\n", cfg.ServerURL)
+	fmt.Fprintf(w, "LDAP Username:\t%s\n", cfg.ReaderDN)
+	fmt.Fprintf(w, "Skip TLS:\t%t\n", cfg.TLSSkipVerify)
+	fmt.Fprintf(w, "JIT User Provisioning:\t%t\n", cfg.JitUserProvisioning)
+
+	w.Flush()
+
+}

--- a/pkg/ucp/types/ucpTypes.go
+++ b/pkg/ucp/types/ucpTypes.go
@@ -143,3 +143,34 @@ type ServiceConfig struct {
 		Data string `json:"Data"`
 	} `json:"Spec"`
 }
+
+// LDAPConfig - This is the LDAP configuration struct
+type LDAPConfig struct {
+	ServerURL          string `json:"serverURL"`
+	NoSimplePagination bool   `json:"noSimplePagination"`
+	StartTLS           bool   `json:"startTLS"`
+	RootCerts          string `json:"rootCerts"`
+	TLSSkipVerify      bool   `json:"tlsSkipVerify"`
+	ReaderDN           string `json:"readerDN"`
+	// This isn't returned from the GET as once the password is added it can't be modified
+	ReaderPassword    string         `json:"readerPassword"`
+	AdditionalDomains []interface{}  `json:"additionalDomains"`
+	UserSearchConfigs []SearchConfig `json:"userSearchConfigs"`
+	AdminSyncOpts     struct {
+		EnableSync         bool   `json:"enableSync"`
+		SelectGroupMembers bool   `json:"selectGroupMembers"`
+		GroupDN            string `json:"groupDN"`
+		GroupMemberAttr    string `json:"groupMemberAttr"`
+		SearchBaseDN       string `json:"searchBaseDN"`
+		SearchScopeSubtree bool   `json:"searchScopeSubtree"`
+		SearchFilter       string `json:"searchFilter"`
+	} `json:"adminSyncOpts"`
+	SyncSchedule        string `json:"syncSchedule"`
+	JitUserProvisioning bool   `json:"jitUserProvisioning"`
+}
+
+// SearchConfig - The configuration for a search struct on an LDAP tree
+type SearchConfig struct {
+	UserAttr string `json:"usernameAttr"`
+	BaseDN   string `json:"baseDN"`
+}

--- a/pkg/ucp/ucpLdap.go
+++ b/pkg/ucp/ucpLdap.go
@@ -1,0 +1,45 @@
+package ucp
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/thebsdbox/diver/pkg/ucp/types"
+)
+
+//GetLDAPInfo - returns all information about the LDAP configuration
+func (c *Client) GetLDAPInfo() (*ucptypes.LDAPConfig, error) {
+	url := fmt.Sprintf("%s/enzi/v0/config/auth/ldap", c.UCPURL)
+
+	response, err := c.getRequest(url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var l ucptypes.LDAPConfig
+
+	err = json.Unmarshal(response, &l)
+	if err != nil {
+		return nil, err
+	}
+
+	return &l, nil
+}
+
+//SetLDAPInfo - returns all information about the LDAP configuration
+func (c *Client) SetLDAPInfo(cfg *ucptypes.LDAPConfig) error {
+	url := fmt.Sprintf("%s/enzi/v0/config/auth/ldap", c.UCPURL)
+
+	b, err := json.Marshal(cfg)
+	if err != nil {
+		return err
+	}
+
+	response, err := c.putRequest(url, b)
+	if err != nil {
+		ParseUCPError(response)
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
- A `get` operation retrieves basic info for an LDAP configuration
- A `set` will create a new config and update the first search config. More support needed for that later.

Fixes #119 